### PR TITLE
Last filtered aggregates adjustments

### DIFF
--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -384,9 +384,6 @@ class Query:
                 new_expr, col_cnt = self.rewrite_cols(expr, col_cnt)
                 new_exprs.append(new_expr)
         annotation.set_source_expressions(new_exprs)
-        filter_ = getattr(annotation, 'filter', None)
-        if filter_:
-            annotation.filter, col_cnt = self.rewrite_cols(filter_, col_cnt)
         return annotation, col_cnt
 
     def get_aggregation(self, using, added_aggregate_names):

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -61,7 +61,7 @@ class FilteredAggregateTestCase(TestCase):
 
     def test_plain_annotate(self):
         agg = Sum('book__pages', filter=Q(book__rating__gt=3))
-        qs = Author.objects.annotate(pages=agg)
+        qs = Author.objects.annotate(pages=agg).order_by('pk')
         self.assertSequenceEqual([a.pages for a in qs], [447, None])
 
     def test_filtered_aggregate_on_annotate(self):


### PR DESCRIPTION
Alright this should the last wave of adjustments.

It removes the `rewrite_cols` `filter` handling and make `Aggregate` a good `source_expressions` citizen. It's heavy inspired by how [`When` deals with that](https://github.com/django/django/blob/c7f6ffbdcf9ca8df905aebf73336ef9905771f7c/django/db/models/expressions.py#L793-L809), the only nuance is that we have to add some conditional logic because `filter` can be `None`.